### PR TITLE
Improve project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,47 @@
-# Introduction
+# List of News Domains
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.15073918.svg)](https://doi.org/10.5281/zenodo.15073918)
 
-The goal of this project is to compile a list of news domains from existing lists for research purposes.
+This repository compiles a canonical list of U.S. news domains from a variety of existing datasets. Researchers can use the list for studies on news consumption, media bias and related topics.
 
-# TL;DR
+## Quick start
 
-Check out the [release](https://github.com/yang3kc/list_of_news_domains/releases) to download the last version of the list.
+The latest version of the list is available on the [releases page](https://github.com/yang3kc/list_of_news_domains/releases) or directly in [data/output/news_domains.csv](data/output/news_domains.csv).
 
-Or access it at: [data/output/news_domains.csv](data/output/news_domains.csv)
+## Repository structure
 
-# Data sources
+```
+.
+├── data/          # raw input lists and final output
+├── notebooks/     # Jupyter notebooks for exploration
+├── workflow/      # cleaning scripts and Snakemake pipeline
+└── README.md      # project overview (this file)
+```
 
-See [data/raw_data](data/raw_data) for the data sources.
+### Data
+- `data/raw_data/` – original source files and exclusion lists
+- `data/output/` – the compiled list of domains
 
-# Workflow
+A full description of each source can be found in [data/raw_data/README.md](data/raw_data/README.md).
 
-See [workflow](workflow) for details of processing steps.
+## Running the pipeline
 
-# Citation
+The build process is managed with [Snakemake](https://snakemake.readthedocs.io). To regenerate `news_domains.csv`:
+
+1. Install the dependencies in a Python environment with `pandas` and `tldextract`.
+2. From the repository root, run `snakemake -j 1`.
+
+Each rule cleans one input dataset and writes a standardized CSV. The cleaned files are concatenated, deduplicated and filtered with the exclusion lists to produce the final output.
+
+### Adding new data sources
+
+Cleaning scripts follow a simple pattern (see `workflow/clean_mbfc.py` for an example). To include another list:
+1. Write a new `clean_*.py` script that outputs a single-column CSV with a `domain` column.
+2. Add a rule to `workflow/Snakefile` and include the resulting file in the `combine_cleaned_data` step.
+
+## Citation
+
+If you use this list, please cite:
 
 ```bibtex
 @dataset{yang2025newsdomains,

--- a/data/README.md
+++ b/data/README.md
@@ -1,9 +1,11 @@
-# Introduction
+# Data directory
 
-This folder stores the raw data and processed data for the project.
+This folder holds both the original source lists and the final compiled dataset.
 
-# File structure
+```
+data/
+├── raw_data/   # input lists and exclusion files
+└── output/     # news_domains.csv
+```
 
-- [raw_data](./raw_data): The raw data for the project.
-- [intermediate_files](./intermediate_files): The intermediate files for the project.
-- [output](./output): The output data for the project.
+Each data source is documented in [raw_data/README.md](raw_data/README.md). The `output` folder contains the single file `news_domains.csv`, which is produced by the Snakemake pipeline.

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,3 +1,8 @@
-# Introduction
+# Notebooks
 
-This folder stores the notebooks for the project.
+A few Jupyter notebooks demonstrate how the lists are cleaned and how to explore the final dataset.
+
+- `data_cleaning.ipynb` – example cleaning steps for one of the sources
+- `explore.ipynb` – quick inspection of `news_domains.csv`
+
+These notebooks are optional and not required to run the Snakemake pipeline.


### PR DESCRIPTION
## Summary
- expand main README with repository structure and instructions for running the pipeline
- update data README to reflect current directory layout
- describe example notebooks in notebooks README

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6898d658832d9d35548f754573b2