### PR TITLE
Filter non-news domains and document think tank retention policy

### DIFF
--- a/data/output/news_domains.csv
+++ b/data/output/news_domains.csv
@@ -4296,7 +4296,6 @@ ahvalnews.com
 beaconjournal.com
 al-monitor.com
 al-sura.com
-guttmacher.org
 albertaviews.ca
 aldergrovestar.com
 allgov.com

--- a/data/output/news_domains.csv
+++ b/data/output/news_domains.csv
@@ -1023,7 +1023,6 @@ epochtimes.fr
 sante.fr
 lavenir.net
 franceculture.fr
-ivg.gouv.fr
 herault-tribune.com
 limportant.fr
 nouvelobs.com
@@ -1047,8 +1046,6 @@ fawkes-news.com
 lesmoutonsrebelles.com
 lelibrepenseur.org
 ripostelaique.com
-sante.gouv.fr
-solidarites-sante.gouv.fr
 patriote.info
 reseauinternational.net
 lesmoutonsenrages.fr
@@ -2170,7 +2167,6 @@ connersclinic.com
 ktva.com
 clevelandclinic.org
 ksfy.com
-who.int
 healthyfoodhouse.com
 thetelegraph.com
 coshoctontribune.com
@@ -2588,7 +2584,6 @@ breitbart.com
 ze-mag.net
 fox4news.com
 fox5dc.com
-nhs.uk
 fox5ny.com
 rightwingpost.com
 breakingnewshouse.com
@@ -2637,7 +2632,6 @@ emedicinehealth.com
 nursingnotes.co.uk
 philly.com
 modernhealthcare.com
-ncic.nhs.uk
 altcoinmercury.com
 conservativeeditionnews.com
 newsela.com
@@ -2681,7 +2675,6 @@ kctv5.com
 nj1015.com
 liberaleditionnews.com
 triad-city-beat.com
-dgt.nhs.uk
 thedodo.com
 inquisitr.com
 hollywoodreporter.com
@@ -3091,7 +3084,6 @@ totalprosports.com
 thepoke.co.uk
 wafb.com
 therealdeal.com
-coastalwestsussexccg.nhs.uk
 independentsentinel.com
 wfmynews2.com
 the74million.org
@@ -3643,7 +3635,6 @@ theroot.com
 wikileaks.com
 rollingstone.com
 benhs.org.uk
-dsptoolkit.nhs.uk
 variety.com
 trunews.com
 hannity.com
@@ -6262,7 +6253,6 @@ vaxopedia.org
 verywellhealth.com
 verywellfamily.com
 verywellfit.com
-wmo.int
 zmescience.com
 adobochronicles.com
 americaslastlineofdefense.com
@@ -15276,7 +15266,6 @@ gearpatrol.com
 geeky-gadgets.com
 gizmodo.co.uk
 goal.com
-gov.uk
 govtech.com
 grapevine.is
 graziadaily.co.uk
@@ -15378,7 +15367,6 @@ publicnewsservice.org
 pv-magazine.com
 pymnts.com
 radaronline.com
-reliefweb.int
 restaurantbusinessonline.com
 road.cc
 roadandtrack.com
@@ -16392,7 +16380,6 @@ jacksoncountystar.com
 kspk.com
 sangredecristosentinel.com
 pikespeakcourier.net
-www.ctn.state.ct.us
 cpbn.org
 ctnewsjunkie.com
 www.connecticut.statenews.net
@@ -20438,7 +20425,6 @@ sjuhawknews.com
 bucknellian.net
 albanystudentpress.net
 peoplenewspapers.com
-state.ct.us
 calvinchimes.org
 choctawsun.com
 claycountydemocrat.com

--- a/data/raw_data/README.md
+++ b/data/raw_data/README.md
@@ -123,3 +123,9 @@ They are:
 - website builders (e.g., wordpress.com, wix.com)
 - blogs (e.g., medium.com)
 - etc.
+
+### Think tanks and policy organizations
+
+The dataset intentionally retains think tanks, policy organizations, and advocacy groups (e.g., `heritage.org`, `brookings.edu`, `cato.org`, `aclu.org`).
+Although these are not traditional news outlets, they regularly publish analysis, commentary, and reporting that functions as news content, especially in political contexts.
+Many of these organizations have strong political leanings, making them relevant for media bias and news consumption analysis.

--- a/data/raw_data/domain_to_exclude.csv
+++ b/data/raw_data/domain_to_exclude.csv
@@ -43,3 +43,4 @@ sante.gouv.fr,foreign government
 solidarites-sante.gouv.fr,foreign government
 www.ctn.state.ct.us,state government
 state.ct.us,state government
+guttmacher.org,research institute

--- a/data/raw_data/domain_to_exclude.csv
+++ b/data/raw_data/domain_to_exclude.csv
@@ -29,3 +29,17 @@ lexisnexis.com,legal database
 researchgate.net,academic platform
 sky.com,streaming service
 jstor.org,academic database
+who.int,intergovernmental organization
+wmo.int,intergovernmental organization
+reliefweb.int,intergovernmental organization
+gov.uk,foreign government
+nhs.uk,foreign government
+ncic.nhs.uk,foreign government
+dgt.nhs.uk,foreign government
+coastalwestsussexccg.nhs.uk,foreign government
+dsptoolkit.nhs.uk,foreign government
+ivg.gouv.fr,foreign government
+sante.gouv.fr,foreign government
+solidarites-sante.gouv.fr,foreign government
+www.ctn.state.ct.us,state government
+state.ct.us,state government

--- a/data/raw_data/domain_to_exclude.csv
+++ b/data/raw_data/domain_to_exclude.csv
@@ -43,4 +43,3 @@ sante.gouv.fr,foreign government
 solidarites-sante.gouv.fr,foreign government
 www.ctn.state.ct.us,state government
 state.ct.us,state government
-guttmacher.org,research institute


### PR DESCRIPTION
## Summary
- Filter out international government and intergovernmental organization domains (e.g., `gov.uk`, `nhs.uk`, `who.int`, `.gouv.fr`) and U.S. state government domains (`state.ct.us`) from the dataset
- Document the intentional retention of think tanks and policy organizations (e.g., `heritage.org`, `brookings.edu`, `cato.org`) in the README, explaining their relevance for media bias and news consumption analysis

## Test plan
- [ ] Run `snakemake -j 1` and verify the pipeline completes successfully
- [ ] Verify excluded domains no longer appear in `data/output/news_domains.csv`
- [ ] Review the new README section for clarity