### PR TITLE
Normalize URL schemes and tighten dedup

### DIFF
--- a/data/output/news_domains.csv
+++ b/data/output/news_domains.csv
@@ -4296,6 +4296,7 @@ ahvalnews.com
 beaconjournal.com
 al-monitor.com
 al-sura.com
+guttmacher.org
 albertaviews.ca
 aldergrovestar.com
 allgov.com
@@ -12665,8 +12666,6 @@ fullmeasure.news
 globalissues.org
 globo.com
 houstondaily.com
-http:kaaltv.com
-http:wnem.com
 ibtimes.co.in
 idaho8.com
 idea.de
@@ -21502,7 +21501,6 @@ wvecho.com
 ctinsider.com
 lakeonews.com
 southcentralfloridalife.com
-NewsHopper.net
 theschoharienews.com
 voicesb.com
 geringcourier.com
@@ -21525,7 +21523,6 @@ republicaneagle.com
 gazetteleader.com
 lesueurcountynews.com
 rockawaytimes.com
-KendallCountyNow.com
 advertisernewssouth.com
 chelseanewsny.com
 lakechamplainweekly.com
@@ -22078,7 +22075,6 @@ grandviewindependent.com
 fresnoland.org
 sjvwater.org
 knock-la.com
-TheEastsiderLA.com
 larchmontbuzz.com
 lapublicpress.org
 witnessla.com
@@ -22138,7 +22134,7 @@ floridabulldog.org
 jaxtoday.org
 jaxtrib.org
 kbindependent.org
-WinterParkVoice.com
+winterparkvoice.com
 bungalower.com
 oviedocommunitynews.org
 wintergardenvox.com
@@ -22214,7 +22210,7 @@ streetcarsuburbs.news
 hyattsvillewire.com
 bowiesun.com
 baltimorefishbowl.com
-SouthBmore.com
+southbmore.com
 thebaltimorebanner.com
 lowercapenews.org
 greylockglass.com
@@ -22222,15 +22218,13 @@ theberkshireedge.com
 theshoestring.org
 lincolnsquirrel.com
 thebedfordcitizen.org
-FigCityNews.com
 burlington.buzz
 yourarlington.com
 binjonline.org
-ActonExchange.org
+actonexchange.org
 theconcordbridge.org
 theframe.news
-WinchesterNews.org
-Brookline.News
+winchesternews.org
 hinghamanchor.com
 theworcesterguardian.org
 greatlakesecho.org
@@ -22293,11 +22287,11 @@ ridgeviewecho.com
 citydesk.org
 grantcountybeat.com
 cloudcroftreader.com
-AlamogordoTownNews.com
+alamogordotownnews.com
 nmindepth.com
 sierracountycitizen.org
 imby.com
-Cortlandvoice.com
+cortlandvoice.com
 investigativepost.org
 buffalorising.com
 tribecacitizen.com
@@ -22317,11 +22311,11 @@ huntingtonnow.com
 eastendbeacon.com
 therivernewsroom.com
 pelhamexaminer.com
-MyRye.com
+myrye.com
 bladenonline.com
 avlwatchdog.org
 borderbelt.org
-CityViewTODAY.com
+cityviewtoday.com
 southpointaccess.news
 theassemblync.com
 northcarolinahealthnews.org
@@ -22335,7 +22329,7 @@ blufftonicon.com
 athensindependent.com
 oxfreepress.com
 cleobserver.com
-TheBuckeyeFlame.com
+thebuckeyeflame.com
 thelandcle.org
 beltmag.com
 matternews.org
@@ -22374,7 +22368,6 @@ cityandstatepa.com
 chaddsfordlive.com
 eriereader.com
 lebtown.com
-NorthcentralPa.com
 presentemedia.org
 sauconsource.com
 westphillylocal.com
@@ -22389,9 +22382,9 @@ pvdeye.org
 sfsimplified.com
 pigeon605.com
 ksgazette.com
-NashvilleBanner.com
+nashvillebanner.com
 thecontributor.org
-Nooga.com
+nooga.com
 indherald.com
 mlk50.com
 psrmemphis.org
@@ -22423,7 +22416,6 @@ utahinvestigative.org
 westviewmedia.org
 afcitizen.com
 newportdispatch.com
-MontpelierBridge.org
 waterburyroundabout.org
 vtdigger.com
 newzgroup.com
@@ -22486,7 +22478,6 @@ baltimorewitness.org
 theswellesleyreport.com
 flintside.com
 modeldmedia.com
-Mississippitoday.org
 missouriindependent.com
 nebraskaexaminer.com
 newhampshirebulletin.com

--- a/workflow/clean_hohenberg.py
+++ b/workflow/clean_hohenberg.py
@@ -19,6 +19,7 @@ python clean_hohenberg.py data/raw/hohenberg.csv hohenberg data/processed/hohenb
 
 import pandas as pd
 import sys
+import utils
 
 input_file = sys.argv[1]
 dataset = sys.argv[2]
@@ -30,7 +31,7 @@ print(f"Load {hohenberg_df.shape[0]} rows from {input_file}.")
 hohenberg_df = hohenberg_df[hohenberg_df.domain.notna()][["domain"]]
 print(f"{len(hohenberg_df)} rows after dropping missing values.")
 
-hohenberg_df["domain"] = hohenberg_df.domain.str.lower()
+hohenberg_df["domain"] = hohenberg_df.domain.apply(utils.normalize_domain)
 
 hohenberg_df = hohenberg_df[~hohenberg_df["domain"].str.contains("/")][["domain"]]
 print(f"{len(hohenberg_df)} rows after removing URLs with paths.")

--- a/workflow/clean_nwu_local_news.py
+++ b/workflow/clean_nwu_local_news.py
@@ -26,7 +26,8 @@ output_file = sys.argv[-1]
 nwu_local_news_df = pd.read_csv(input_file, usecols=["domain"])
 print(f"Load {nwu_local_news_df.shape[0]} rows from {input_file}.")
 
+nwu_local_news_df["domain"] = nwu_local_news_df.domain.str.lower()
+
 nwu_local_news_df["dataset"] = dataset
 
-# The dataset has been cleaned already, so no need to further clean it
 nwu_local_news_df.to_csv(output_file, index=False)

--- a/workflow/gen_unique_data.py
+++ b/workflow/gen_unique_data.py
@@ -23,6 +23,7 @@ output_file = sys.argv[-1]
 
 df = pd.read_csv(input_file, usecols=["domain"])
 
+df["domain"] = df["domain"].str.lower()
 df.drop_duplicates(subset=["domain"], inplace=True)
 
 df.to_csv(output_file, index=False)

--- a/workflow/utils.py
+++ b/workflow/utils.py
@@ -1,5 +1,23 @@
 from urllib.parse import urlparse
+import re
 import tldextract
+
+
+def normalize_domain(raw):
+    """
+    Normalize a raw domain or URL string to a bare lowercase domain name.
+
+    Handles:
+    - Bare domains: 'example.com' → 'example.com'
+    - Full URLs: 'http://example.com' → 'example.com'
+    - Malformed schemes (missing //): 'http:example.com' → 'example.com'
+    """
+    raw = raw.strip().lower()
+    # Fix missing // after http: or https: (e.g., "http:example.com")
+    raw = re.sub(r"^(https?):(?!//)", r"\1://", raw)
+    if raw.startswith("http://") or raw.startswith("https://"):
+        return extract_domain(raw)
+    return raw
 
 
 def has_path(url):


### PR DESCRIPTION
## Summary

- **URL normalization**: Added `normalize_domain()` to `utils.py` that fixes malformed `http:foo` entries (missing `//`) and extracts bare domain names from URL-like strings. Applied in `clean_hohenberg.py` — fixes `http:kaaltv.com` → `kaaltv.com` and `http:wnem.com` → `wnem.com` reported in #12.
- **Dedup fix**: Added lowercasing to `clean_nwu_local_news.py` (the NWU dataset had mixed-case entries like `Brookline.News`, `FigCityNews.com`, etc.) and added a catch-all lowercase normalization before dedup in `gen_unique_data.py`. Resolves the 8 duplicate domains reported in #12.
- **Dead domains**: Intentionally not removed — retained for historical data analysis.

## Test plan

- [ ] `grep -E 'https?:[^/]' data/output/news_domains.csv` returns nothing
- [ ] `grep -E '^(kaaltv\.com|wnem\.com)$' data/output/news_domains.csv` returns both corrected entries
- [ ] `awk '{print tolower($1)}' data/output/news_domains.csv | sort | uniq -d` returns nothing